### PR TITLE
Default wrapX to false for WMS layer.

### DIFF
--- a/src/ol/source/tilewms.js
+++ b/src/ol/source/tilewms.js
@@ -48,7 +48,7 @@ ol.source.TileWMS = function(opt_options) {
     tileLoadFunction: options.tileLoadFunction,
     url: options.url,
     urls: options.urls,
-    wrapX: options.wrapX !== undefined ? options.wrapX : true,
+    wrapX: options.wrapX !== undefined ? options.wrapX : false,
     transition: options.transition
   });
 


### PR DESCRIPTION
It's a fix for this following defect in tfs: 
Defect 914280:AlimMap>BG Map is displayed multiple times 