### PR TITLE
Updating createFunction of Style.js to use duck typing to check for Style object

### DIFF
--- a/src/ol/style/style.js
+++ b/src/ol/style/style.js
@@ -291,9 +291,10 @@ ol.style.Style.createFunction = function(obj) {
     if (Array.isArray(obj)) {
       styles = obj;
     } else {
-      ol.asserts.assert(obj instanceof ol.style.Style,
-          41); // Expected an `ol.style.Style` or an array of `ol.style.Style`
-      styles = [obj];
+      ol.asserts.assert(typeof(obj).getZIndex === 'function',
+        41); // Expected an `ol.style.Style` or an array of `ol.style.Style`
+      const style = (obj);
+      styles = [style];
     }
     styleFunction = function() {
       return styles;


### PR DESCRIPTION
'Instanceof'  check was throwing assertion error for OpenUtilities project with ol.js file and working fine with ol-debug.js file. Reason being that Style object and Style class against which it was comparing are getting created from different constructors. After looking into it further, found that latest code of Openlayers has replaced all instanceof checks with other logic against pullrequest:
https://github.com/openlayers/openlayers/commit/9163558511715d5f391388e949110fecfc414198#diff-4e288335d9131e7053362e2a88cff4e9.

- [ ] This pull request addresses an issue that has been marked with the 'Pull request accepted' label & I have added the link to that issue.
- [ ] It contains one or more small, incremental, logically separate commits, with no merge commits.
- [ ] I have used clear commit messages.
- [ ] Existing tests pass for me locally & I have added or updated tests for new or changed functionality.
